### PR TITLE
Better float highlighting

### DIFF
--- a/syntaxes/ante.tmLanguage.json
+++ b/syntaxes/ante.tmLanguage.json
@@ -149,6 +149,10 @@
 				},
 				{
 					"name": "constant.numeric.ante",
+					"match": "\\b[0-9_]+\\.[0-9_]+(f(32|64))\\b"
+				},
+				{
+					"name": "constant.numeric.ante",
 					"match": "\\b0b[01_]+([ui](8|16|32|64|sz))?\\b"
 				},
 				{

--- a/syntaxes/ante.tmLanguage.json
+++ b/syntaxes/ante.tmLanguage.json
@@ -149,7 +149,7 @@
 				},
 				{
 					"name": "constant.numeric.ante",
-					"match": "\\b[0-9_]+\\.[0-9_]+(f(32|64))\\b"
+					"match": "\\b[0-9_]+\\.[0-9_]+(f(32|64))?\\b"
 				},
 				{
 					"name": "constant.numeric.ante",


### PR DESCRIPTION
It should highlight `1.0f32` and `1.0f64` correctly now (i think)